### PR TITLE
Feature: Add aws provider definition with aws profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ tf-module-s3                        // generates `module "myModuleName" { source
 
 ```bash
 tf-aws                              // generates `provider "aws" { ... }`
+tf-aws-profile                       // generates `provider "aws" { profile = "", shared_credentials_file="",... }`
 tf-google                           // generates `provider "google" { ... }`
 tf-openstack                        // generates `provider "openstack" { ... }`
 ```

--- a/snippets/terraform.json
+++ b/snippets/terraform.json
@@ -52,6 +52,17 @@
             "}"
         ]
     },
+    "aws-profile": {
+        "prefix": "tf-aws-profile",
+        "description": "define a aws provider with profile.",
+        "body": [
+            "provider \"aws\" {",
+            "   region = \"${1:AWS REGION}\"",
+            "   shared_credentials_file = \"${2:path/to/.aws/creds}\"",
+            "   profile = \"${3:AWS PROFILE}\"",
+            "}"
+        ]
+    },
     "depends_on": {
         "prefix": "tf-depends_on",
         "description": "Define explicit dependencies.",


### PR DESCRIPTION
Hi,
I want to contribute, so add a snippet that output aws provider definition with aws profile like in the doc : https://www.terraform.io/docs/providers/aws/index.html#shared-credentials-file

---
**Given** : A user editing a terraform file on vscode
**When** : He enters `tf-aws-profile`
**Then** : The editor must output the following snippet 
```hcl
provider "aws" {
   region = "AWS REGION"
   shared_credentials_file = "path/to/.aws/creds"
   profile = "AWS PROFILE"
}
```

Hope It helps :)
Regards