### PR TITLE
fix: Fix cloudflare_record snippet

### DIFF
--- a/src/providers/cloudflare.json
+++ b/src/providers/cloudflare.json
@@ -13,7 +13,7 @@
         "prefix":"tf-cloudflare_record",
         "description": "Defines cloudflare_record resource",
         "body": [
-            "resource \"chef_role\" \"${MyResource}\" {",
+            "resource \"cloudflare_record\" \"${MyResource}\" {",
             "   domain = \"cloudflare_domain\"",
             "   name = \"terraform\"",
             "   value = \"192.168.0.11\"",


### PR DESCRIPTION
tf-cloudflare_record snippet was a chef role

I did generate the snippets file but it created many differences due to some ^M (CRLF) characters in random places.